### PR TITLE
Feat: add default show prop for controlling calendar state after sele…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ with yarn
 | inputClass           | string                                                     | null      |
 | inputAttributes      | object of InputHTMLAttributes                              | null      |
 | className            | string                                                     | null      |
-| customShowDateFormat | string  ex: YYYY MMMM DD or DD/MM etc.                     | undefined |
-| position             | right &#124; left  &#124; center                           | right     |
-
+| customShowDateFormat | string ex: YYYY MMMM DD or DD/MM etc.                      | undefined |
+| position             | right &#124; left &#124; center                            | right     |
+| defaultShow          | string; one of close open                                  | open      |
 
 ### Calendar Provider
 

--- a/src/hooks/useCalendarHandlers.tsx
+++ b/src/hooks/useCalendarHandlers.tsx
@@ -1,6 +1,6 @@
 import { type SyntheticEvent, useState } from 'react'
 import dayjs from 'dayjs'
-import type { DatePickerValue } from '../types'
+import type { DatePickerValue, DefaultShow } from '../types'
 import type {
   CalendarDefaultProps,
   CalendarRangeProps
@@ -13,7 +13,13 @@ interface BaseUseCalendarHandlersType {
   to?: DatePickerValue
 }
 
+interface ControlCalendarDisplay {
+  setShowCalendar?: (args: boolean) => void
+  defaultShow?: DefaultShow
+}
+
 type useCalendarHandlersType = BaseUseCalendarHandlersType &
+  ControlCalendarDisplay &
   (CalendarRangeProps | CalendarDefaultProps)
 
 export const guardRange = (
@@ -30,6 +36,13 @@ export const useCalendarHandlers = (props: useCalendarHandlersType) => {
   const [to, setTo] = useState<Date | undefined | null>(
     props.to !== undefined ? new Date(props.to) : undefined
   )
+
+  const checkToCloseCalenderAfterSelect = () => {
+    const shouldCloseAfterSelect = props.defaultShow === 'close'
+
+    if (shouldCloseAfterSelect && props.setShowCalendar !== undefined)
+      props.setShowCalendar(false)
+  }
 
   const onClickCalendar = (e: Event) => {
     const { value, disabled } = e.currentTarget.dataset
@@ -68,6 +81,7 @@ export const useCalendarHandlers = (props: useCalendarHandlersType) => {
     if (selectingRange && to !== undefined) {
       handleRangeOnChange(from, to)
       setSelectingRange(false)
+      checkToCloseCalenderAfterSelect()
     }
   }
   const onMouseMove = (e: Event) => {
@@ -85,6 +99,7 @@ export const useCalendarHandlers = (props: useCalendarHandlersType) => {
     if (props.range === true) {
       return onClickRange(e)
     }
+    checkToCloseCalenderAfterSelect()
     return onClickCalendar(e)
   }
   const handleRangeOnChange = (

--- a/src/packages/Calendar/Calendar.types.ts
+++ b/src/packages/Calendar/Calendar.types.ts
@@ -2,13 +2,16 @@ import type {
   DaysRange,
   DatePickerValue,
   onRangeDatePickerChangePayload,
-  onDatePickerChangePayload
+  onDatePickerChangePayload,
+  DefaultShow
 } from '../../types'
 
 export interface CalendarBaseProps {
   defaultValue?: Date
   weekends?: DaysRange[]
   className?: string
+  defaultShow?: DefaultShow
+  setShowCalendar?: (args: boolean) => void
 }
 export interface CalendarRangeProps {
   range: true

--- a/src/packages/DatePicker/DatePicker.tsx
+++ b/src/packages/DatePicker/DatePicker.tsx
@@ -15,7 +15,8 @@ export const DatePicker = (props: DatePickerProps) => {
     locale = 'fa',
     weekends = [],
     direction = 'rtl',
-    accentColor
+    accentColor,
+    defaultShow = 'open'
   } = props
   useMemo(() => localeCache.setLocale(locale), [locale])
   // refs
@@ -35,7 +36,7 @@ export const DatePicker = (props: DatePickerProps) => {
       ? new Date(props.to)
       : undefined
   )
-  const [showCalendar, setShowCalendar] = useState<boolean>(false)
+  const [showCalendar, setShowCalendar] = useState<boolean>(true)
   // hooks
   useClickOutside(containerRef, () => setShowCalendar(false))
   // handlers
@@ -112,6 +113,8 @@ export const DatePicker = (props: DatePickerProps) => {
           range={props.range}
           from={props.range === true ? props.from : undefined}
           to={props.range === true ? props.to : undefined}
+          setShowCalendar={setShowCalendar}
+          defaultShow={defaultShow}
         />
       </RenderCalendar>
     </CalendarProvider>

--- a/src/packages/DatePicker/DatePicker.types.ts
+++ b/src/packages/DatePicker/DatePicker.types.ts
@@ -3,7 +3,8 @@ import type {
   BaseProps,
   DatePickerValue,
   DaysRange,
-  Positions
+  Positions,
+  DefaultShow
 } from '../../types'
 import type {
   CalendarDefaultProps,
@@ -14,6 +15,7 @@ export interface DatePickerBaseProps extends BaseProps {
   defaultValue?: DatePickerValue
   weekends?: DaysRange[]
   show?: boolean
+  defaultShow?: DefaultShow
   inputClass?: string
   className?: string
   inputAttributes?: InputHTMLAttributes<HTMLInputElement>

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export type Pickers = 'days' | 'year' | 'month'
 
 export type Positions = 'right' | 'left' | 'center'
 
+export type DefaultShow = 'open' | 'close'
+
 export interface BaseProps {
   round?: Radius
   accentColor?: string


### PR DESCRIPTION
As suggested in the https://github.com/rzkhosroshahi/zaman/issues/113 issue thread by the package author I added  a `defaultShow` prop for controlling the calendar's state after selection